### PR TITLE
Fixes for recent ansible versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,7 +191,7 @@ hashicorp__src: '{{ (ansible_local.root.src
                      if (ansible_local|d() and ansible_local.root|d() and
                          ansible_local.root.src|d())
                      else "/usr/local/src") + "/" + hashicorp__user + "/" +
-                     (hashicorp__base_url.split("://")|last | split("/") | first) }}'
+                     (hashicorp__base_url|urlsplit("hostname")) }}'
 
                                                                    # ]]]
 # .. envvar:: hashicorp__lib [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,9 +116,9 @@
       with_nested:
         - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
         - [ '{{ hashicorp__tar_suffix }}', '{{ hashicorp__hash_suffix }}', '{{ hashicorp__sig_suffix }}' ]
-      when: (ansible_local is undefined or (ansible_local|d() and (ansible_local.hashicorp is undefined or
-             (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
-              (ansible_local.hashicorp.applications[item.0] is undefined or
+      when: (ansible_local is undefined or (ansible_local is defined and (ansible_local.hashicorp is undefined or
+                 (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
+                   (ansible_local.hashicorp.applications[item.0] is undefined or
                (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
       tags: [ 'role::hashicorp:download', 'role::hashicorp:verify' ]
 
@@ -133,8 +133,8 @@
         - [ '{{ hashicorp__consul_webui_suffix }}' ]
       when: (hashicorp__consul_webui|bool and
              ('consul' in (hashicorp__applications + hashicorp__dependent_applications) | unique) and
-              (ansible_local is undefined or (ansible_local|d() and ansible_local.hashicorp is undefined or
-               (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
+              (ansible_local is undefined or (ansible_local is defined and ansible_local.hashicorp is undefined or
+               (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
                 (ansible_local.hashicorp.applications['consul'] is undefined or
                  (ansible_local.hashicorp.applications['consul'] != hashicorp__combined_version_map['consul'])) or
                 not ansible_local.hashicorp.consul_webui | bool))))
@@ -178,7 +178,7 @@
         dest: '{{ hashicorp__lib + "/" + item + "/" + hashicorp__combined_version_map[item] }}'
         creates: '{{ hashicorp__lib + "/" + item + "/" + hashicorp__combined_version_map[item] + "/" +
                      ((hashicorp__combined_binary_map[item] if hashicorp__combined_binary_map[item] is string else hashicorp__combined_binary_map[item]|first)
-                      if hashicorp__combined_binary_map[item]|d() else item) }}'
+                      if hashicorp__combined_binary_map[item] is defined else item) }}'
       with_items: '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
       register: hashicorp__register_unpack
       tags: [ 'role::hashicorp:unpack', 'role::hashicorp:install' ]
@@ -201,7 +201,7 @@
 - name: Install HashiCorp applications
   shell: install --mode 755 --owner root --group root --target-directory {{ hashicorp__bin }}
          {{ ((hashicorp__combined_binary_map[item.0] if hashicorp__combined_binary_map[item.0] is string else hashicorp__combined_binary_map[item.0] | join(' '))
-             if hashicorp__combined_binary_map[item.0]|d() else item.0) }}
+             if hashicorp__combined_binary_map[item.0] is defined else item.0) }}
          {% if item.0 == 'terraform' %}
          ; find . -maxdepth 1 -type f -name 'terraform-*' -exec install -m 755 -o root -g root -t {{ hashicorp__bin }} {} +
          {% endif %}
@@ -210,9 +210,9 @@
   with_together:
     - '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
     - '{{ hashicorp__register_unpack.results }}'
-  when: (item.1|changed or (ansible_local|d() and
+  when: (item.1|changed or (ansible_local is defined and
          (ansible_local.hashicorp is undefined or
-          (ansible_local.hashicorp|d() and ansible_local.hashicorp.applications|d() and
+          (ansible_local.hashicorp is defined and ansible_local.hashicorp.applications is defined and
            (ansible_local.hashicorp.applications[item.0] is undefined or
             (ansible_local.hashicorp.applications[item.0] != hashicorp__combined_version_map[item.0]))))))
   tags: [ 'role::hashicorp:install' ]


### PR DESCRIPTION
A series of fixes were needed to get this module working on recent ansible versions (at least 2.4.3).

First, a fix for conditional logic by removing `var|d()` structures.  The `var|d()` pattern isn't working as intended.  Have verified that changing the conditional commands to use the `is defined` is correctly
evaluating the conditions.

Second, replace `split|last|first` with `urlsplit()` filter as the pattern is no longer working in ansible-2.4.3.  In any case the use of the `urlsplit()` filter is much more readable.