### PR TITLE
Tighten permissions on the data directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
     state: 'directory'
     owner: '{{ hashicorp__user }}'
     group: '{{ hashicorp__group }}'
-    mode: '0755'
+    mode: '0750'
   with_items: '{{ (hashicorp__applications + hashicorp__dependent_applications) | unique }}'
   when: (hashicorp__applications or hashicorp__dependent_applications)
   tags: [ 'role::hashicorp:unpack', 'role::hashicorp:install' ]


### PR DESCRIPTION
The data directory shouldn't really be world readable, much like an MTA
or DB.  Restrict permissions to 0750 so only the service user can enter.